### PR TITLE
Fix check on AIX to determine if a file system is local

### DIFF
--- a/common/autoconf/basics.m4
+++ b/common/autoconf/basics.m4
@@ -1156,10 +1156,18 @@ AC_DEFUN([BASIC_CHECK_DIR_ON_LOCAL_DISK],
       $2
     fi
   else
-    if $DF -l $1 > /dev/null 2>&1; then
-      $2
+    if test "x$OPENJDK_BUILD_OS_ENV" = "xaix"; then
+      if $DF -T local $1 > /dev/null 2>&1; then
+        $2
+      else
+        $3
+      fi
     else
-      $3
+      if $DF -l $1 > /dev/null 2>&1; then
+        $2
+      else
+        $3
+      fi
     fi
   fi
 ])

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -5186,7 +5186,7 @@ VS_SDK_PLATFORM_NAME_2013=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1496926402
+DATE_WHEN_GENERATED=1508410971
 
 ###############################################################################
 #
@@ -67475,7 +67475,7 @@ $as_echo_n "checking if build directory is on local disk... " >&6; }
       OUTPUT_DIR_IS_LOCAL="yes"
     fi
   else
-    if [ $OPENJDK_BUILD_OS_ENV = aix ]; then
+    if test "x$OPENJDK_BUILD_OS_ENV" = "xaix"; then
       if $DF -T local $OUTPUT_ROOT > /dev/null 2>&1; then
         OUTPUT_DIR_IS_LOCAL="yes"
       else

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -67475,10 +67475,18 @@ $as_echo_n "checking if build directory is on local disk... " >&6; }
       OUTPUT_DIR_IS_LOCAL="yes"
     fi
   else
-    if $DF -l $OUTPUT_ROOT > /dev/null 2>&1; then
-      OUTPUT_DIR_IS_LOCAL="yes"
+    if [ $OPENJDK_BUILD_OS_ENV = aix ]; then
+      if $DF -T local $OUTPUT_ROOT > /dev/null 2>&1; then
+        OUTPUT_DIR_IS_LOCAL="yes"
+      else
+        OUTPUT_DIR_IS_LOCAL="no"
+      fi
     else
-      OUTPUT_DIR_IS_LOCAL="no"
+      if $DF -l $OUTPUT_ROOT > /dev/null 2>&1; then
+        OUTPUT_DIR_IS_LOCAL="yes"
+      else
+        OUTPUT_DIR_IS_LOCAL="no"
+      fi
     fi
   fi
 


### PR DESCRIPTION
Assuming modifying generated-configure.sh is valid, this will fix the fact that AIX currently claims it's output directory is not on a local filesystem when it really is.
 
Alternative solution 1: Use /usr/sysv/bin/df (which doesn't work unless you specify the root of the mounted file system)
Alternative solution 2: Implement a check for the validity of `df -l` and do the check on the basis of that instead of the `OPENJDK_BUILD_OS_ENV` variable.

Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/181 in this repo. When accepted I'll replicate in https://github.com/adoptopenjdk/openjdk-jdk8u and https://github.com/ibmruntimes/openj9-openjdk-jdk9